### PR TITLE
Define openApiUrl for website

### DIFF
--- a/currency-converter-connector-product/product.json
+++ b/currency-converter-connector-product/product.json
@@ -1,4 +1,7 @@
 {
+  "properties": {
+    "openApiUrl": "openapi.json"
+  },
 	"installers": [
 		{
 			"id": "maven-import",


### PR DESCRIPTION
Website is parsing the product.json and is looking for openApiUrl property.

We may should automatically detect a openapi.json file, but what if you point to an external URL?